### PR TITLE
Improves API and Spring-based repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 allprojects {
     group 'eu.socialedge.ddd'
-    version '0.1'
+    version '0.2'
 }
 
 subprojects {
@@ -29,6 +29,7 @@ subprojects {
 
     dependencies {
         compileOnly libraries.gen.lombok
+        testCompileOnly libraries.gen.lombok
     }
 
     task sourceJar(type: Jar) {

--- a/ddd-api/build.gradle
+++ b/ddd-api/build.gradle
@@ -1,3 +1,5 @@
+description 'Provides building blocks for domain driven development'
+
 configurations {
     jpaMetamodel
 }

--- a/ddd-api/src/main/java/eu/socialedge/ddd/domain/AggregateRoot.java
+++ b/ddd-api/src/main/java/eu/socialedge/ddd/domain/AggregateRoot.java
@@ -1,6 +1,5 @@
 package eu.socialedge.ddd.domain;
 
-import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 /**
@@ -15,7 +14,7 @@ import lombok.NoArgsConstructor;
  * @see <a href="https://martinfowler.com/bliki/DDD_Aggregate.html">
  *     DDD_Aggregate - Martin Fowler</a>
  */
-@NoArgsConstructor(force = true, access = AccessLevel.PACKAGE)
+@NoArgsConstructor(force = true)
 public abstract class AggregateRoot<T extends Identifier<?>> extends Entity<T> {
 
     protected AggregateRoot(T id) {

--- a/ddd-api/src/main/java/eu/socialedge/ddd/domain/DeactivatableAggregateRoot.java
+++ b/ddd-api/src/main/java/eu/socialedge/ddd/domain/DeactivatableAggregateRoot.java
@@ -1,6 +1,5 @@
 package eu.socialedge.ddd.domain;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
@@ -11,7 +10,7 @@ import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 
 @Getter @Accessors(fluent = true)
-@NoArgsConstructor(force = true, access = AccessLevel.PACKAGE)
+@NoArgsConstructor(force = true)
 @MappedSuperclass @Access(AccessType.FIELD)
 public abstract class DeactivatableAggregateRoot<T extends Identifier<?>> extends AggregateRoot<T> {
 
@@ -20,6 +19,11 @@ public abstract class DeactivatableAggregateRoot<T extends Identifier<?>> extend
 
     protected DeactivatableAggregateRoot(T id) {
         super(id);
+    }
+
+    protected DeactivatableAggregateRoot(T id, boolean isActive) {
+        super(id);
+        this.isActive = isActive;
     }
 
     public void activate() {

--- a/ddd-api/src/main/java/eu/socialedge/ddd/domain/Entity.java
+++ b/ddd-api/src/main/java/eu/socialedge/ddd/domain/Entity.java
@@ -1,14 +1,13 @@
 package eu.socialedge.ddd.domain;
 
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
-import javax.persistence.Access;
-import javax.persistence.AccessType;
-import javax.persistence.EmbeddedId;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 
-import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.Validate.notNull;
 
 /**
  * A {@link ValueObject} fundamentally defined not by its
@@ -34,17 +33,21 @@ import static java.util.Objects.requireNonNull;
  *
  * @param <T> concrete {@link Identifier} type implementation
  */
-@Getter @Setter
 @EqualsAndHashCode
 @Accessors(fluent = true)
-@NoArgsConstructor(force = true, access = AccessLevel.PACKAGE)
+@NoArgsConstructor(force = true)
 @MappedSuperclass @Access(AccessType.FIELD)
 public abstract class Entity<T extends Identifier<?>> {
 
+    @Getter
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @EmbeddedId
     protected final T id;
 
+    @Version
+    private Long version;
+
     protected Entity(T id) {
-        this.id = requireNonNull(id);
+        this.id = notNull(id);
     }
 }

--- a/ddd-api/src/main/java/eu/socialedge/ddd/domain/Identifier.java
+++ b/ddd-api/src/main/java/eu/socialedge/ddd/domain/Identifier.java
@@ -5,10 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
-import javax.persistence.Access;
-import javax.persistence.AccessType;
-import javax.persistence.Column;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -33,6 +30,7 @@ import java.util.Objects;
 @MappedSuperclass @Access(AccessType.FIELD)
 public abstract class Identifier<T extends Serializable> extends ValueObject {
 
+    @GeneratedValue
     @Column(name = "value", nullable = false)
     protected final T value;
 

--- a/ddd-api/src/main/java/eu/socialedge/ddd/domain/UuId.java
+++ b/ddd-api/src/main/java/eu/socialedge/ddd/domain/UuId.java
@@ -1,0 +1,26 @@
+package eu.socialedge.ddd.domain;
+
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.MappedSuperclass;
+import java.util.UUID;
+
+/**
+ * {@link UUID} based implementation of {@link Identifier}
+ */
+@Accessors(fluent = true)
+@EqualsAndHashCode(callSuper = false)
+@MappedSuperclass @Access(AccessType.FIELD)
+public class UuId extends Identifier<UUID> {
+
+    public UuId() {
+        super(UUID.randomUUID());
+    }
+
+    public UuId(UUID uuid) {
+        super(uuid);
+    }
+}

--- a/ddd-api/src/main/java/eu/socialedge/ddd/domain/repository/MindfulRepository.java
+++ b/ddd-api/src/main/java/eu/socialedge/ddd/domain/repository/MindfulRepository.java
@@ -5,7 +5,6 @@ import eu.socialedge.ddd.domain.Identifier;
 
 import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Represents a mutable {@link Repository} implementation that introduces
@@ -18,29 +17,15 @@ import java.util.stream.Collectors;
 public interface MindfulRepository<ID extends Identifier<?>, T extends DeactivatableAggregateRoot<ID>>
         extends ExpandableRepository<ID, T> {
 
-    void activate(ID id);
+    boolean containsActive(ID id);
 
-    default void activate(T entity) {
-        activate(entity.id());
-    }
+    void activate(ID id);
 
     void activate(Iterable<ID> entityIds);
 
-    default void activate(Collection<T> entities) {
-        activate(entities.stream().map(T::id).collect(Collectors.toList()));
-    }
-
     void deactivate(ID id);
 
-    default void deactivate(T entity) {
-        deactivate(entity.id());
-    }
-
     void deactivate(Iterable<ID> entityIds);
-
-    default void deactivate(Collection<T> entities) {
-        deactivate(entities.stream().map(T::id).collect(Collectors.toList()));
-    }
 
     Optional<T> getActive(ID id);
 

--- a/ddd-api/src/main/java/eu/socialedge/ddd/domain/repository/Repository.java
+++ b/ddd-api/src/main/java/eu/socialedge/ddd/domain/repository/Repository.java
@@ -26,7 +26,9 @@ public interface Repository<ID extends Identifier<?>, T extends AggregateRoot<ID
 
     long size();
 
-    boolean isEmpty();
+    default boolean isEmpty() {
+        return size() == 0L;
+    }
 
     Optional<T> get(ID id);
 

--- a/ddd-event-spring-cloud/build.gradle
+++ b/ddd-event-spring-cloud/build.gradle
@@ -1,7 +1,10 @@
+description 'Provides Spring Cloud Stream - based implementation of domain event Publisher and Registrar'
+
 dependencies {
     compile project(":ddd-api")
 
     compile libraries.bus.springCloudStream
 
-    testCompile libraries.test.springCloudStreamTest
+    testCompile libraries.test.springBoot
+    testCompile libraries.test.springCloudStream
 }

--- a/ddd-event-spring-cloud/src/test/java/eu/socialedge/ddd/infrastructure/eventbus/SpringDomainEventRegistrarTest.java
+++ b/ddd-event-spring-cloud/src/test/java/eu/socialedge/ddd/infrastructure/eventbus/SpringDomainEventRegistrarTest.java
@@ -2,7 +2,6 @@ package eu.socialedge.ddd.infrastructure.eventbus;
 
 import eu.socialedge.ddd.event.DomainEvent;
 import eu.socialedge.ddd.event.DomainEventHandler;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -66,7 +65,7 @@ public class SpringDomainEventRegistrarTest {
         verifyZeroInteractions(childDomainEventHandler);
     }
 
-    @Test @Ignore
+    @Test
     public void shouldCallAllHandlersDespiteExceptions() {
         eventRegistrar.registerEventHandler(firstHandler, DomainEvent.class);
         eventRegistrar.registerEventHandler(firstHandler, DomainEvent.class);

--- a/ddd-repository-spring-data/build.gradle
+++ b/ddd-repository-spring-data/build.gradle
@@ -1,5 +1,11 @@
+description 'Provides Spring Data Jpa - based implementation of domain repositories'
+
 dependencies {
     compile project(":ddd-api")
 
     compile libraries.persistence.springDataJpa
+
+    testCompile libraries.test.springBoot
+    testCompile libraries.test.springBootDataJpaStarter
+    testCompile libraries.test.h2database
 }

--- a/ddd-repository-spring-data/src/main/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringExpandableRepository.java
+++ b/ddd-repository-spring-data/src/main/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringExpandableRepository.java
@@ -3,6 +3,7 @@ package eu.socialedge.ddd.infrastructure.persistence.jpa;
 import eu.socialedge.ddd.domain.AggregateRoot;
 import eu.socialedge.ddd.domain.Identifier;
 import eu.socialedge.ddd.domain.repository.ExpandableRepository;
+import eu.socialedge.ddd.domain.repository.RepositoryException;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,9 @@ public interface SpringExpandableRepository<ID extends Identifier<?>, T extends 
     @Override
     @Transactional
     default void add(T entity) {
+        if (contains(entity.id()))
+            throw new RepositoryException("Entity already exists");
+
         exec(() -> save(entity));
     }
 

--- a/ddd-repository-spring-data/src/main/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMindfulRepository.java
+++ b/ddd-repository-spring-data/src/main/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMindfulRepository.java
@@ -28,6 +28,13 @@ public interface SpringMindfulRepository<ID extends Identifier<?>, T extends Dea
         extends MindfulRepository<ID, T>, SpringExpandableRepository<ID, T>, JpaSpecificationExecutor<T> {
 
     @Override
+    default boolean containsActive(ID id) {
+        val entityOpt = get(id);
+        return entityOpt.map(DeactivatableAggregateRoot::isActive).orElse(false);
+
+    }
+
+    @Override
     @Transactional
     default void activate(ID id) {
         val entity = get(id).orElseThrow(()

--- a/ddd-repository-spring-data/src/main/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMindfulRepository.java
+++ b/ddd-repository-spring-data/src/main/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMindfulRepository.java
@@ -31,7 +31,6 @@ public interface SpringMindfulRepository<ID extends Identifier<?>, T extends Dea
     default boolean containsActive(ID id) {
         val entityOpt = get(id);
         return entityOpt.map(DeactivatableAggregateRoot::isActive).orElse(false);
-
     }
 
     @Override
@@ -41,7 +40,6 @@ public interface SpringMindfulRepository<ID extends Identifier<?>, T extends Dea
             -> new RepositoryException("Cannot activate entity: Entity not found"));
 
         entity.activate();
-        save(entity);
     }
 
     @Override
@@ -57,7 +55,6 @@ public interface SpringMindfulRepository<ID extends Identifier<?>, T extends Dea
             -> new RepositoryException("Cannot deactivate entity: Entity not found"));
 
         entity.deactivate();
-        save(entity);
     }
 
     @Override

--- a/ddd-repository-spring-data/src/main/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepository.java
+++ b/ddd-repository-spring-data/src/main/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepository.java
@@ -51,11 +51,6 @@ public interface SpringRepository<ID extends Identifier<?>, T extends AggregateR
     }
 
     @Override
-    default boolean isEmpty() {
-        return size() == 0L;
-    }
-
-    @Override
     default Optional<T> get(ID id) {
         Validate.notNull(id, "Identifier cannot be null");
 

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringExpandableRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringExpandableRepositoryTest.java
@@ -38,12 +38,11 @@ public class SpringExpandableRepositoryTest {
     @Test
     public void shouldAddEnt1tyCorrectly() {
         val entity = randomEnt1ty();
-        val entityId = entity.id();
 
         entityRepository.add(entity);
         assertEquals(1L, entityRepository.size());
 
-        val savedEntityOpt = entityRepository.get(entityId);
+        val savedEntityOpt = entityRepository.get(entity.id());
 
         assertTrue(savedEntityOpt.isPresent());
         assertEquals(entity, savedEntityOpt.get());
@@ -59,20 +58,18 @@ public class SpringExpandableRepositoryTest {
 
         assertTrue(entityRepository.size() == entities.size());
         assertTrue(entities.containsAll(savedEntities));
-        assertTrue(savedEntities.containsAll(entities));
     }
 
     @Test
     @Transactional
     public void shouldListenEnt1tyChanges() {
         val entity = randomEnt1ty();
-        val entityId = entity.id();
 
         entityRepository.add(entity);
 
         entity.field = "FAILED?";
 
-        val savedEntity = entityRepository.get(entityId).get();
+        val savedEntity = entityRepository.get(entity.id()).get();
         assertEquals(entity, savedEntity);
     }
 

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringExpandableRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringExpandableRepositoryTest.java
@@ -41,9 +41,7 @@ public class SpringExpandableRepositoryTest {
         val entityId = entity.id();
 
         entityRepository.add(entity);
-
-        assertFalse(entityRepository.isEmpty());
-        assertTrue(entityRepository.size() == 1L);
+        assertEquals(1L, entityRepository.size());
 
         val savedEntityOpt = entityRepository.get(entityId);
 
@@ -59,7 +57,6 @@ public class SpringExpandableRepositoryTest {
 
         val savedEntities = entityRepository.list();
 
-        assertFalse(savedEntities.isEmpty());
         assertTrue(entityRepository.size() == entities.size());
         assertTrue(entities.containsAll(savedEntities));
         assertTrue(savedEntities.containsAll(entities));

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringExpandableRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringExpandableRepositoryTest.java
@@ -1,0 +1,90 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa;
+
+import eu.socialedge.ddd.domain.repository.RepositoryException;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1ty;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.repository.Ent1tyExpandableRepository;
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import static eu.socialedge.ddd.infrastructure.persistence.jpa.domain.util.Ent1ties.randomEnt1ties;
+import static eu.socialedge.ddd.infrastructure.persistence.jpa.domain.util.Ent1ties.randomEnt1ty;
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@SpringBootTest(classes = SpringRepositoryTestConfig.class)
+public class SpringExpandableRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private Ent1tyExpandableRepository entityRepository;
+
+    @Before
+    public void setUp() {
+        entityManager.clear();
+        entityManager.flush();
+    }
+
+    @Test
+    public void shouldAddEnt1tyCorrectly() {
+        val randEntity = randomEnt1ty();
+        val randEntityId = randEntity.id();
+
+        entityRepository.add(randEntity);
+
+        assertFalse(entityRepository.isEmpty());
+        assertTrue(entityRepository.size() == 1L);
+
+        val repoEntityOpt = entityRepository.get(randEntityId);
+
+        assertTrue(repoEntityOpt.isPresent());
+        assertEquals(randEntity, repoEntityOpt.get());
+    }
+
+    @Test
+    public void shouldAddEnt1tyListCorrectly() {
+        val randEntities = randomEnt1ties(5);
+
+        entityRepository.add(randEntities);
+
+        val repoEntities = entityRepository.list();
+
+        assertFalse(repoEntities.isEmpty());
+        assertTrue(entityRepository.size() == randEntities.size());
+        assertTrue(randEntities.containsAll(repoEntities));
+        assertTrue(repoEntities.containsAll(randEntities));
+    }
+
+    @Test
+    @Transactional
+    public void shouldListenEnt1tyChanges() {
+        val randEntity = randomEnt1ty();
+        val randEntityId = randEntity.id();
+
+        entityRepository.add(randEntity);
+
+        randEntity.field = "FAILED?";
+
+        val repoEntity = entityRepository.get(randEntityId).get();
+        assertEquals(randEntity, repoEntity);
+    }
+
+    @Test(expected = RepositoryException.class)
+    public void shouldNotOverrideEntityWithTheSameId() throws CloneNotSupportedException {
+        val randOrigEntity = randomEnt1ty();
+        val randCopyEntity = (Ent1ty) randOrigEntity.clone();
+
+        entityRepository.add(randOrigEntity);
+        entityRepository.add(randCopyEntity);
+    }
+}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringExpandableRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringExpandableRepositoryTest.java
@@ -37,46 +37,46 @@ public class SpringExpandableRepositoryTest {
 
     @Test
     public void shouldAddEnt1tyCorrectly() {
-        val randEntity = randomEnt1ty();
-        val randEntityId = randEntity.id();
+        val entity = randomEnt1ty();
+        val entityId = entity.id();
 
-        entityRepository.add(randEntity);
+        entityRepository.add(entity);
 
         assertFalse(entityRepository.isEmpty());
         assertTrue(entityRepository.size() == 1L);
 
-        val repoEntityOpt = entityRepository.get(randEntityId);
+        val savedEntityOpt = entityRepository.get(entityId);
 
-        assertTrue(repoEntityOpt.isPresent());
-        assertEquals(randEntity, repoEntityOpt.get());
+        assertTrue(savedEntityOpt.isPresent());
+        assertEquals(entity, savedEntityOpt.get());
     }
 
     @Test
     public void shouldAddEnt1tyListCorrectly() {
-        val randEntities = randomEnt1ties(5);
+        val entities = randomEnt1ties(5);
 
-        entityRepository.add(randEntities);
+        entityRepository.add(entities);
 
-        val repoEntities = entityRepository.list();
+        val savedEntities = entityRepository.list();
 
-        assertFalse(repoEntities.isEmpty());
-        assertTrue(entityRepository.size() == randEntities.size());
-        assertTrue(randEntities.containsAll(repoEntities));
-        assertTrue(repoEntities.containsAll(randEntities));
+        assertFalse(savedEntities.isEmpty());
+        assertTrue(entityRepository.size() == entities.size());
+        assertTrue(entities.containsAll(savedEntities));
+        assertTrue(savedEntities.containsAll(entities));
     }
 
     @Test
     @Transactional
     public void shouldListenEnt1tyChanges() {
-        val randEntity = randomEnt1ty();
-        val randEntityId = randEntity.id();
+        val entity = randomEnt1ty();
+        val entityId = entity.id();
 
-        entityRepository.add(randEntity);
+        entityRepository.add(entity);
 
-        randEntity.field = "FAILED?";
+        entity.field = "FAILED?";
 
-        val repoEntity = entityRepository.get(randEntityId).get();
-        assertEquals(randEntity, repoEntity);
+        val savedEntity = entityRepository.get(entityId).get();
+        assertEquals(entity, savedEntity);
     }
 
     @Test(expected = RepositoryException.class)

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMindfulRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMindfulRepositoryTest.java
@@ -1,0 +1,108 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa;
+
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.repository.Ent1tyMindfulRepository;
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static eu.socialedge.ddd.infrastructure.persistence.jpa.domain.util.Ent1ties.randomMindfulEnt1ties;
+import static eu.socialedge.ddd.infrastructure.persistence.jpa.domain.util.Ent1ties.randomMindfulEnt1ty;
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@SpringBootTest(classes = SpringRepositoryTestConfig.class)
+public class SpringMindfulRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private Ent1tyMindfulRepository entityRepository;
+
+    @Before
+    public void setUp() {
+        entityManager.clear();
+        entityManager.flush();
+    }
+
+    @Test
+    public void shouldActivateEntityCorrectly() {
+        val randEntity = randomMindfulEnt1ty(false);
+        val randEntityId = randEntity.id();
+        entityRepository.add(randEntity);
+
+        entityRepository.activate(randEntityId);
+
+        assertTrue(entityRepository.get(randEntityId).get().isActive());
+    }
+
+    @Test
+    public void shouldDeactivateEntityCorrectly() {
+        val randEntity = randomMindfulEnt1ty(true);
+        val randEntityId = randEntity.id();
+        entityRepository.add(randEntity);
+
+        entityRepository.deactivate(randEntityId);
+
+        assertFalse(entityRepository.get(randEntityId).get().isActive());
+    }
+
+    @Test
+    public void shouldListOnlyActiveEntities() {
+        val inactiveRandEntity = randomMindfulEnt1ty(false);
+        entityRepository.add(inactiveRandEntity);
+
+        val activeRandEntities = randomMindfulEnt1ties(5);
+        entityRepository.add(activeRandEntities);
+
+        val activeRepoEntities = entityRepository.listActive();
+
+        assertEquals(activeRandEntities.size(), activeRepoEntities.size());
+        assertTrue(activeRepoEntities.containsAll(activeRandEntities));
+        assertTrue(activeRandEntities.containsAll(activeRepoEntities));
+    }
+
+    @Test
+    public void shouldCheckForEntityExistenceCorrectly() {
+        val randActiveEntity = randomMindfulEnt1ty();
+        val randInactiveEntity = randomMindfulEnt1ty(false);
+        entityRepository.add(randActiveEntity);
+        entityRepository.add(randInactiveEntity);
+
+        assertTrue(entityRepository.containsActive(randActiveEntity.id()));
+        assertFalse(entityRepository.containsActive(randInactiveEntity.id()));
+        assertTrue(entityRepository.contains(randActiveEntity.id()));
+    }
+
+    @Test
+    public void shouldListEntitiesEntities() {
+        val randActiveEntities = randomMindfulEnt1ties(5);
+        val randInactiveEntities = randomMindfulEnt1ties(5, false);
+        entityRepository.add(randActiveEntities);
+        entityRepository.add(randInactiveEntities);
+
+        val repoActiveEntities = entityRepository.listActive();
+        assertEquals(randActiveEntities.size(), repoActiveEntities.size());
+        assertTrue(repoActiveEntities.containsAll(randActiveEntities));
+        assertTrue(randActiveEntities.containsAll(repoActiveEntities));
+
+        val repoAllEntities = entityRepository.list();
+        val randEntitiesUnion = Stream
+            .concat(randActiveEntities.stream(), randInactiveEntities.stream())
+            .collect(Collectors.toList());
+
+        assertEquals(randEntitiesUnion.size(), repoAllEntities.size());
+        assertTrue(randEntitiesUnion.containsAll(repoAllEntities));
+        assertTrue(repoAllEntities.containsAll(randEntitiesUnion));
+    }
+}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMindfulRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMindfulRepositoryTest.java
@@ -38,23 +38,21 @@ public class SpringMindfulRepositoryTest {
     @Test
     public void shouldActivateEntityCorrectly() {
         val entity = randomMindfulEnt1ty(false);
-        val entityId = entity.id();
         entityRepository.add(entity);
 
-        entityRepository.activate(entityId);
+        entityRepository.activate(entity.id());
 
-        assertTrue(entityRepository.get(entityId).get().isActive());
+        assertTrue(entityRepository.get(entity.id()).get().isActive());
     }
 
     @Test
     public void shouldDeactivateEntityCorrectly() {
         val entity = randomMindfulEnt1ty(true);
-        val entityId = entity.id();
         entityRepository.add(entity);
 
-        entityRepository.deactivate(entityId);
+        entityRepository.deactivate(entity.id());
 
-        assertFalse(entityRepository.get(entityId).get().isActive());
+        assertFalse(entityRepository.get(entity.id()).get().isActive());
     }
 
     @Test
@@ -69,7 +67,6 @@ public class SpringMindfulRepositoryTest {
 
         assertEquals(activeRandEntities.size(), activeSavedEntities.size());
         assertTrue(activeSavedEntities.containsAll(activeRandEntities));
-        assertTrue(activeRandEntities.containsAll(activeSavedEntities));
     }
 
     @Test
@@ -94,7 +91,6 @@ public class SpringMindfulRepositoryTest {
         val savedActiveEntities = entityRepository.listActive();
         assertEquals(randActiveEntities.size(), savedActiveEntities.size());
         assertTrue(savedActiveEntities.containsAll(randActiveEntities));
-        assertTrue(randActiveEntities.containsAll(savedActiveEntities));
 
         val savedAllEntities = entityRepository.list();
         val entitiesUnion = Stream
@@ -103,6 +99,5 @@ public class SpringMindfulRepositoryTest {
 
         assertEquals(entitiesUnion.size(), savedAllEntities.size());
         assertTrue(entitiesUnion.containsAll(savedAllEntities));
-        assertTrue(savedAllEntities.containsAll(entitiesUnion));
     }
 }

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMindfulRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMindfulRepositoryTest.java
@@ -37,24 +37,24 @@ public class SpringMindfulRepositoryTest {
 
     @Test
     public void shouldActivateEntityCorrectly() {
-        val randEntity = randomMindfulEnt1ty(false);
-        val randEntityId = randEntity.id();
-        entityRepository.add(randEntity);
+        val entity = randomMindfulEnt1ty(false);
+        val entityId = entity.id();
+        entityRepository.add(entity);
 
-        entityRepository.activate(randEntityId);
+        entityRepository.activate(entityId);
 
-        assertTrue(entityRepository.get(randEntityId).get().isActive());
+        assertTrue(entityRepository.get(entityId).get().isActive());
     }
 
     @Test
     public void shouldDeactivateEntityCorrectly() {
-        val randEntity = randomMindfulEnt1ty(true);
-        val randEntityId = randEntity.id();
-        entityRepository.add(randEntity);
+        val entity = randomMindfulEnt1ty(true);
+        val entityId = entity.id();
+        entityRepository.add(entity);
 
-        entityRepository.deactivate(randEntityId);
+        entityRepository.deactivate(entityId);
 
-        assertFalse(entityRepository.get(randEntityId).get().isActive());
+        assertFalse(entityRepository.get(entityId).get().isActive());
     }
 
     @Test
@@ -65,11 +65,11 @@ public class SpringMindfulRepositoryTest {
         val activeRandEntities = randomMindfulEnt1ties(5);
         entityRepository.add(activeRandEntities);
 
-        val activeRepoEntities = entityRepository.listActive();
+        val activeSavedEntities = entityRepository.listActive();
 
-        assertEquals(activeRandEntities.size(), activeRepoEntities.size());
-        assertTrue(activeRepoEntities.containsAll(activeRandEntities));
-        assertTrue(activeRandEntities.containsAll(activeRepoEntities));
+        assertEquals(activeRandEntities.size(), activeSavedEntities.size());
+        assertTrue(activeSavedEntities.containsAll(activeRandEntities));
+        assertTrue(activeRandEntities.containsAll(activeSavedEntities));
     }
 
     @Test
@@ -91,18 +91,18 @@ public class SpringMindfulRepositoryTest {
         entityRepository.add(randActiveEntities);
         entityRepository.add(randInactiveEntities);
 
-        val repoActiveEntities = entityRepository.listActive();
-        assertEquals(randActiveEntities.size(), repoActiveEntities.size());
-        assertTrue(repoActiveEntities.containsAll(randActiveEntities));
-        assertTrue(randActiveEntities.containsAll(repoActiveEntities));
+        val savedActiveEntities = entityRepository.listActive();
+        assertEquals(randActiveEntities.size(), savedActiveEntities.size());
+        assertTrue(savedActiveEntities.containsAll(randActiveEntities));
+        assertTrue(randActiveEntities.containsAll(savedActiveEntities));
 
-        val repoAllEntities = entityRepository.list();
-        val randEntitiesUnion = Stream
+        val savedAllEntities = entityRepository.list();
+        val entitiesUnion = Stream
             .concat(randActiveEntities.stream(), randInactiveEntities.stream())
             .collect(Collectors.toList());
 
-        assertEquals(randEntitiesUnion.size(), repoAllEntities.size());
-        assertTrue(randEntitiesUnion.containsAll(repoAllEntities));
-        assertTrue(repoAllEntities.containsAll(randEntitiesUnion));
+        assertEquals(entitiesUnion.size(), savedAllEntities.size());
+        assertTrue(entitiesUnion.containsAll(savedAllEntities));
+        assertTrue(savedAllEntities.containsAll(entitiesUnion));
     }
 }

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMutableRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMutableRepositoryTest.java
@@ -1,5 +1,6 @@
 package eu.socialedge.ddd.infrastructure.persistence.jpa;
 
+import eu.socialedge.ddd.domain.Entity;
 import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.repository.Ent1tyMutableRepository;
 import lombok.val;
 import org.junit.Before;
@@ -36,35 +37,35 @@ public class SpringMutableRepositoryTest {
 
     @Test
     public void shouldRemoveEntityCorrectly() {
-        val randEntity = randomEnt1ty();
+        val entity = randomEnt1ty();
 
-        entityRepository.add(randEntity);
+        entityRepository.add(entity);
 
-        entityRepository.remove(randEntity);
+        entityRepository.remove(entity);
         assertTrue(entityRepository.isEmpty());
         assertTrue(entityRepository.size() == 0);
     }
 
     @Test
     public void shouldRemoveEntityByIdCorrectly() {
-        val randEntity = randomEnt1ty();
-        val randEntityId = randEntity.id();
+        val entity = randomEnt1ty();
+        val entityId = entity.id();
 
-        entityRepository.add(randEntity);
+        entityRepository.add(entity);
 
-        entityRepository.remove(randEntityId);
+        entityRepository.remove(entityId);
         assertTrue(entityRepository.isEmpty());
         assertTrue(entityRepository.size() == 0);
     }
 
     @Test
     public void shouldRemoveEntitiesByIdListCorrectly() {
-        val randEntities = randomEnt1ties(5);
-        val randEntitiesId = randEntities.stream().map(e -> e.id()).collect(Collectors.toList());
+        val entities = randomEnt1ties(5);
+        val entitiesId = entities.stream().map(Entity::id).collect(Collectors.toList());
 
-        entityRepository.add(randEntities);
+        entityRepository.add(entities);
 
-        entityRepository.remove(randEntitiesId);
+        entityRepository.remove(entitiesId);
         assertTrue(entityRepository.isEmpty());
         assertTrue(entityRepository.size() == 0);
     }

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMutableRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMutableRepositoryTest.java
@@ -1,0 +1,80 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa;
+
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.repository.Ent1tyMutableRepository;
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.stream.Collectors;
+
+import static eu.socialedge.ddd.infrastructure.persistence.jpa.domain.util.Ent1ties.randomEnt1ties;
+import static eu.socialedge.ddd.infrastructure.persistence.jpa.domain.util.Ent1ties.randomEnt1ty;
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@SpringBootTest(classes = SpringRepositoryTestConfig.class)
+public class SpringMutableRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private Ent1tyMutableRepository entityRepository;
+
+    @Before
+    public void setUp() {
+        entityManager.clear();
+        entityManager.flush();
+    }
+
+    @Test
+    public void shouldRemoveEntityCorrectly() {
+        val randEntity = randomEnt1ty();
+
+        entityRepository.add(randEntity);
+
+        entityRepository.remove(randEntity);
+        assertTrue(entityRepository.isEmpty());
+        assertTrue(entityRepository.size() == 0);
+    }
+
+    @Test
+    public void shouldRemoveEntityByIdCorrectly() {
+        val randEntity = randomEnt1ty();
+        val randEntityId = randEntity.id();
+
+        entityRepository.add(randEntity);
+
+        entityRepository.remove(randEntityId);
+        assertTrue(entityRepository.isEmpty());
+        assertTrue(entityRepository.size() == 0);
+    }
+
+    @Test
+    public void shouldRemoveEntitiesByIdListCorrectly() {
+        val randEntities = randomEnt1ties(5);
+        val randEntitiesId = randEntities.stream().map(e -> e.id()).collect(Collectors.toList());
+
+        entityRepository.add(randEntities);
+
+        entityRepository.remove(randEntitiesId);
+        assertTrue(entityRepository.isEmpty());
+        assertTrue(entityRepository.size() == 0);
+    }
+
+    @Test
+    public void shouldClearCorrectly() {
+        entityRepository.add(randomEnt1ties(5));
+
+        entityRepository.clear();
+        assertTrue(entityRepository.isEmpty());
+        assertTrue(entityRepository.size() == 0);
+    }
+}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMutableRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMutableRepositoryTest.java
@@ -43,7 +43,6 @@ public class SpringMutableRepositoryTest {
 
         entityRepository.remove(entity);
         assertTrue(entityRepository.isEmpty());
-        assertTrue(entityRepository.size() == 0);
     }
 
     @Test
@@ -55,7 +54,6 @@ public class SpringMutableRepositoryTest {
 
         entityRepository.remove(entityId);
         assertTrue(entityRepository.isEmpty());
-        assertTrue(entityRepository.size() == 0);
     }
 
     @Test
@@ -67,7 +65,6 @@ public class SpringMutableRepositoryTest {
 
         entityRepository.remove(entitiesId);
         assertTrue(entityRepository.isEmpty());
-        assertTrue(entityRepository.size() == 0);
     }
 
     @Test
@@ -76,6 +73,5 @@ public class SpringMutableRepositoryTest {
 
         entityRepository.clear();
         assertTrue(entityRepository.isEmpty());
-        assertTrue(entityRepository.size() == 0);
     }
 }

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMutableRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringMutableRepositoryTest.java
@@ -48,11 +48,10 @@ public class SpringMutableRepositoryTest {
     @Test
     public void shouldRemoveEntityByIdCorrectly() {
         val entity = randomEnt1ty();
-        val entityId = entity.id();
 
         entityRepository.add(entity);
 
-        entityRepository.remove(entityId);
+        entityRepository.remove(entity.id());
         assertTrue(entityRepository.isEmpty());
     }
 

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepositoryTest.java
@@ -38,9 +38,8 @@ public class SpringRepositoryTest {
     @Test
     public void shouldContainSavedEntity() {
         val entity = persistRandomEntity();
-        val entityId = entity.id();
 
-        assertTrue(entityRepository.contains(entityId));
+        assertTrue(entityRepository.contains(entity.id()));
     }
 
     @Test
@@ -54,9 +53,8 @@ public class SpringRepositoryTest {
     @Test
     public void shouldRetrieveEntityCorrectly() {
         val entity = persistRandomEntity();
-        val entityId = entity.id();
 
-        val savedEntityOpt = entityRepository.get(entityId);
+        val savedEntityOpt = entityRepository.get(entity.id());
 
         assertTrue(savedEntityOpt.isPresent());
         assertEquals(entity, savedEntityOpt.get());

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepositoryTest.java
@@ -68,7 +68,6 @@ public class SpringRepositoryTest {
 
         val savedEntities = entityRepository.list();
 
-        assertFalse(savedEntities.isEmpty());
         assertEquals(entities.size(), (int) entityRepository.size());
         assertTrue(entities.containsAll(savedEntities));
         assertTrue(savedEntities.containsAll(entities));

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepositoryTest.java
@@ -1,0 +1,90 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa;
+
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1ty;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.repository.Ent1tyRepository;
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Collection;
+
+import static eu.socialedge.ddd.infrastructure.persistence.jpa.domain.util.Ent1ties.randomEnt1ties;
+import static eu.socialedge.ddd.infrastructure.persistence.jpa.domain.util.Ent1ties.randomEnt1ty;
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@SpringBootTest(classes = SpringRepositoryTestConfig.class)
+public class SpringRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private Ent1tyRepository entityRepository;
+
+    @Before
+    public void setUp() {
+        entityManager.clear();
+        entityManager.flush();
+    }
+
+    @Test
+    public void shouldContainSavedEntity() {
+        val randEntity = persistRandomEntity();
+        val randEntityId = randEntity.id();
+
+        assertTrue(entityRepository.contains(randEntityId));
+    }
+
+    @Test
+    public void shouldReturnCorrectSize() {
+        val randEntities = persistRandomEnt1ties(5);
+
+        assertFalse(entityRepository.isEmpty());
+        assertEquals(randEntities.size(), (int) entityRepository.size());
+    }
+
+    @Test
+    public void shouldRetrieveEntityCorrectly() {
+        val randEntity = persistRandomEntity();
+        val randEntityId = randEntity.id();
+
+        val repoEntityOpt = entityRepository.get(randEntityId);
+
+        assertTrue(repoEntityOpt.isPresent());
+        assertEquals(randEntity, repoEntityOpt.get());
+    }
+
+    @Test
+    public void shouldRetrieveEntityListCorrectly() {
+        val randEntities = persistRandomEnt1ties(5);
+
+        val repoEntities = entityRepository.list();
+
+        assertFalse(repoEntities.isEmpty());
+        assertEquals(randEntities.size(), (int) entityRepository.size());
+        assertTrue(randEntities.containsAll(repoEntities));
+        assertTrue(repoEntities.containsAll(randEntities));
+    }
+
+    private Ent1ty persistRandomEntity() {
+        val randEntity = randomEnt1ty();
+
+        entityManager.persist(randEntity);
+        return randEntity;
+    }
+
+    private Collection<Ent1ty> persistRandomEnt1ties(int size) {
+        val randEntities = randomEnt1ties(size);
+
+        randEntities.forEach(entityManager::persist);
+        return randEntities;
+    }
+}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepositoryTest.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepositoryTest.java
@@ -37,54 +37,54 @@ public class SpringRepositoryTest {
 
     @Test
     public void shouldContainSavedEntity() {
-        val randEntity = persistRandomEntity();
-        val randEntityId = randEntity.id();
+        val entity = persistRandomEntity();
+        val entityId = entity.id();
 
-        assertTrue(entityRepository.contains(randEntityId));
+        assertTrue(entityRepository.contains(entityId));
     }
 
     @Test
     public void shouldReturnCorrectSize() {
-        val randEntities = persistRandomEnt1ties(5);
+        val entities = persistRandomEnt1ties(5);
 
         assertFalse(entityRepository.isEmpty());
-        assertEquals(randEntities.size(), (int) entityRepository.size());
+        assertEquals(entities.size(), (int) entityRepository.size());
     }
 
     @Test
     public void shouldRetrieveEntityCorrectly() {
-        val randEntity = persistRandomEntity();
-        val randEntityId = randEntity.id();
+        val entity = persistRandomEntity();
+        val entityId = entity.id();
 
-        val repoEntityOpt = entityRepository.get(randEntityId);
+        val savedEntityOpt = entityRepository.get(entityId);
 
-        assertTrue(repoEntityOpt.isPresent());
-        assertEquals(randEntity, repoEntityOpt.get());
+        assertTrue(savedEntityOpt.isPresent());
+        assertEquals(entity, savedEntityOpt.get());
     }
 
     @Test
     public void shouldRetrieveEntityListCorrectly() {
-        val randEntities = persistRandomEnt1ties(5);
+        val entities = persistRandomEnt1ties(5);
 
-        val repoEntities = entityRepository.list();
+        val savedEntities = entityRepository.list();
 
-        assertFalse(repoEntities.isEmpty());
-        assertEquals(randEntities.size(), (int) entityRepository.size());
-        assertTrue(randEntities.containsAll(repoEntities));
-        assertTrue(repoEntities.containsAll(randEntities));
+        assertFalse(savedEntities.isEmpty());
+        assertEquals(entities.size(), (int) entityRepository.size());
+        assertTrue(entities.containsAll(savedEntities));
+        assertTrue(savedEntities.containsAll(entities));
     }
 
     private Ent1ty persistRandomEntity() {
-        val randEntity = randomEnt1ty();
+        val entity = randomEnt1ty();
 
-        entityManager.persist(randEntity);
-        return randEntity;
+        entityManager.persist(entity);
+        return entity;
     }
 
     private Collection<Ent1ty> persistRandomEnt1ties(int size) {
-        val randEntities = randomEnt1ties(size);
+        val entities = randomEnt1ties(size);
 
-        randEntities.forEach(entityManager::persist);
-        return randEntities;
+        entities.forEach(entityManager::persist);
+        return entities;
     }
 }

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepositoryTestConfig.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/SpringRepositoryTestConfig.java
@@ -1,0 +1,7 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringRepositoryTestConfig {
+}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/Ent1ty.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/Ent1ty.java
@@ -1,0 +1,32 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa.domain;
+
+import eu.socialedge.ddd.domain.AggregateRoot;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Entity
+@Access(AccessType.FIELD)
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@NoArgsConstructor(force = true)
+public class Ent1ty extends AggregateRoot<Ent1tyId> implements Cloneable {
+
+    @Column(nullable = false)
+    public String field;
+
+    public Ent1ty(Ent1tyId id, String field) {
+        super(id);
+        this.field = field;
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return new Ent1ty(id, field);
+    }
+}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/Ent1tyId.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/Ent1tyId.java
@@ -1,0 +1,15 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa.domain;
+
+import eu.socialedge.ddd.domain.Identifier;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(force = true)
+public class Ent1tyId extends Identifier<Long> {
+    public Ent1tyId(Long value) {
+        super(value);
+    }
+
+    public static Ent1tyId of(Long id) {
+        return new Ent1tyId(id);
+    }
+}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/MindfulEnt1ty.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/MindfulEnt1ty.java
@@ -1,0 +1,31 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa.domain;
+
+import eu.socialedge.ddd.domain.DeactivatableAggregateRoot;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Entity
+@Access(AccessType.FIELD)
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@NoArgsConstructor(force = true)
+public class MindfulEnt1ty extends DeactivatableAggregateRoot<Ent1tyId> {
+
+    @Column(nullable = false)
+    String field;
+
+    public MindfulEnt1ty(Ent1tyId id, String field, boolean isActive) {
+        super(id, isActive);
+        this.field = field;
+    }
+
+    public MindfulEnt1ty(Ent1tyId id, String field) {
+        this(id, field, true);
+    }
+}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/repository/Ent1tyExpandableRepository.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/repository/Ent1tyExpandableRepository.java
@@ -1,0 +1,10 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa.domain.repository;
+
+import eu.socialedge.ddd.domain.repository.ExpandableRepository;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.SpringExpandableRepository;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1ty;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1tyId;
+
+@org.springframework.stereotype.Repository
+public interface Ent1tyExpandableRepository extends ExpandableRepository<Ent1tyId, Ent1ty>,
+        SpringExpandableRepository<Ent1tyId, Ent1ty> {}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/repository/Ent1tyMindfulRepository.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/repository/Ent1tyMindfulRepository.java
@@ -1,0 +1,10 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa.domain.repository;
+
+import eu.socialedge.ddd.domain.repository.MindfulRepository;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.SpringMindfulRepository;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1tyId;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.MindfulEnt1ty;
+
+@org.springframework.stereotype.Repository
+public interface Ent1tyMindfulRepository extends MindfulRepository<Ent1tyId, MindfulEnt1ty>,
+        SpringMindfulRepository<Ent1tyId, MindfulEnt1ty> {}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/repository/Ent1tyMutableRepository.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/repository/Ent1tyMutableRepository.java
@@ -1,0 +1,10 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa.domain.repository;
+
+import eu.socialedge.ddd.domain.repository.MutableRepository;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.SpringMutableRepository;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1ty;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1tyId;
+
+@org.springframework.stereotype.Repository
+public interface Ent1tyMutableRepository extends MutableRepository<Ent1tyId, Ent1ty>,
+        SpringMutableRepository<Ent1tyId, Ent1ty> {}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/repository/Ent1tyRepository.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/repository/Ent1tyRepository.java
@@ -1,0 +1,9 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa.domain.repository;
+
+import eu.socialedge.ddd.domain.repository.Repository;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.SpringRepository;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1ty;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1tyId;
+
+@org.springframework.stereotype.Repository
+public interface Ent1tyRepository extends Repository<Ent1tyId, Ent1ty>, SpringRepository<Ent1tyId, Ent1ty> {}

--- a/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/util/Ent1ties.java
+++ b/ddd-repository-spring-data/src/test/java/eu/socialedge/ddd/infrastructure/persistence/jpa/domain/util/Ent1ties.java
@@ -1,0 +1,60 @@
+package eu.socialedge.ddd.infrastructure.persistence.jpa.domain.util;
+
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1ty;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.Ent1tyId;
+import eu.socialedge.ddd.infrastructure.persistence.jpa.domain.MindfulEnt1ty;
+import lombok.val;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+public final class Ent1ties {
+
+    private Ent1ties() {
+        throw new AssertionError("No instance for you");
+    }
+
+    public static Ent1ty randomEnt1ty() {
+        val randString = UUID.randomUUID().toString();
+        val randLong = ThreadLocalRandom.current().nextLong(1, 10000);
+
+        return new Ent1ty(Ent1tyId.of(randLong), randString);
+    }
+
+    public static MindfulEnt1ty randomMindfulEnt1ty(boolean isActive) {
+        val randString = UUID.randomUUID().toString();
+        val randLong = ThreadLocalRandom.current().nextLong(1, 10000);
+
+        return new MindfulEnt1ty(Ent1tyId.of(randLong), randString, isActive);
+    }
+
+    public static MindfulEnt1ty randomMindfulEnt1ty() {
+        return randomMindfulEnt1ty(true);
+    }
+
+    public static Collection<Ent1ty> randomEnt1ties(int size) {
+        val ent1ties = new ArrayList<Ent1ty>(size);
+
+        for (int i = 0; i < size; i++) {
+            ent1ties.add(randomEnt1ty());
+        }
+
+        return ent1ties;
+    }
+
+    public static Collection<MindfulEnt1ty> randomMindfulEnt1ties(int size, boolean isActive) {
+        val ent1ties = new ArrayList<MindfulEnt1ty>(size);
+
+        for (int i = 0; i < size; i++) {
+            ent1ties.add(randomMindfulEnt1ty(isActive));
+        }
+
+        return ent1ties;
+    }
+
+    public static Collection<MindfulEnt1ty> randomMindfulEnt1ties(int size) {
+        return randomMindfulEnt1ties(size, true);
+    }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,7 +17,8 @@ ext {
             ],
             test: [
                 junit: '4.+',
-                springBootTest: '1.4.4.RELEASE',
+                springBoot: '1.4.4.RELEASE',
+                h2database: '1.4.193',
                 assertj: '3.6.+',
                 mockito: '2.2.+'
             ]
@@ -51,10 +52,10 @@ ext {
                 "junit:junit:${versions.libraries.test.junit}",
                 "org.assertj:assertj-core:${versions.libraries.test.assertj}"
             ],
-            springCloudStreamTest: [
-                "org.springframework.boot:spring-boot-starter-test:${versions.libraries.test.springBootTest}",
-                "org.springframework.cloud:spring-cloud-stream-test-support:${versions.libraries.bus.springCloudStream}"
-            ],
+            springBoot: "org.springframework.boot:spring-boot-starter-test:${versions.libraries.test.springBoot}",
+            springBootDataJpaStarter: "org.springframework.boot:spring-boot-starter-data-jpa:${versions.libraries.test.springBoot}",
+            h2database: "com.h2database:h2:${versions.libraries.test.h2database}",
+            springCloudStream: "org.springframework.cloud:spring-cloud-stream-test-support:${versions.libraries.bus.springCloudStream}",
             mockito: "org.mockito:mockito-core:${versions.libraries.test.mockito}"
         ]
     ]


### PR DESCRIPTION
* Add MindfulRepo#containsActive method and remove useles de/activate(entity)
* Fix package private API empty constuctors
* Enable Spring Repositories to track changes in added entities (em#persist usage)
* Cover Spring-based rpositories with tests
* Add UUID based Identifier implementation for convenience
* Minor API and Spring Repositories improvements